### PR TITLE
Improve UI with bottom menu and player cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # sandbox
-experimental codex
+
+Aplicación simple para registrar y evaluar jugadores de fútbol.
+
+Abre `index.html` en tu navegador para comenzar. Los datos se guardan en el `localStorage` del navegador. Desde la pestaña **Datos** puedes exportar e importar un archivo JSON para mantener una copia permanente de la información. Al pulsar **Exportar Datos** se descargará un fichero `entreno.json` con tu información actual.
+
+Selecciona un jugador para ver su historial de evaluaciones. Cada registro puede compararse con la media del equipo haciendo clic en **Comparar**.
+La sección de comparación muestra una tabla con los valores y una gráfica radar para visualizar las diferencias.
+
+La interfaz cuenta ahora con un menú inferior fijo con cuatro opciones: **Inicio**, **Jugadores**, **Evaluar** y **Datos**. En la pestaña *Jugadores* se muestran tarjetas estilo "fantasy" con la media de cada jugador y el número de evaluaciones registradas.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,326 @@
+const playersKey = 'players';
+const evaluationsKey = 'evaluations';
+const evalKeys = [
+  'energia',
+  'concentracion',
+  'control',
+  'pase',
+  'regate',
+  'disparo',
+  'vision',
+  'velocidad'
+];
+
+let compareChart = null;
+
+let players = JSON.parse(localStorage.getItem(playersKey) || '[]');
+let evaluations = JSON.parse(localStorage.getItem(evaluationsKey) || '[]');
+
+function savePlayers() {
+  localStorage.setItem(playersKey, JSON.stringify(players));
+}
+
+function saveEvaluations() {
+  localStorage.setItem(evaluationsKey, JSON.stringify(evaluations));
+}
+
+function renderPlayers() {
+  const list = document.getElementById('players-list');
+  list.innerHTML = '';
+  players.forEach(player => {
+    const li = document.createElement('li');
+    const btn = document.createElement('button');
+    btn.textContent = player.name;
+    btn.onclick = () => selectPlayer(player.id);
+    li.appendChild(btn);
+    list.appendChild(li);
+  });
+}
+
+function renderPlayerCards() {
+  const container = document.getElementById('players-cards');
+  if (!container) return;
+  container.innerHTML = '';
+  players.forEach(p => {
+    const avg = playerAverage(p.id);
+    const evalCount = evaluations.filter(e => e.playerId === p.id).length;
+    const card = document.createElement('div');
+    card.className = 'player-card';
+    card.innerHTML = `
+      <h3>${p.name}</h3>
+      <p>${p.pos1}${p.pos2 ? ' / ' + p.pos2 : ''}</p>
+      <p>Evaluaciones: ${evalCount}</p>
+      <ul>
+        ${evalKeys.map(k => `<li>${k}: ${avg ? avg[k].toFixed(1) : '-'}</li>`).join('')}
+      </ul>
+    `;
+    container.appendChild(card);
+  });
+}
+
+function selectPlayer(id) {
+  const player = players.find(p => p.id === id);
+  if (!player) return;
+  document.getElementById('evaluation-player-name').textContent = player.name;
+  document.getElementById('player-id').value = player.id;
+  document.getElementById('player-name').value = player.name;
+  document.getElementById('player-pos1').value = player.pos1;
+  document.getElementById('player-pos2').value = player.pos2 || '';
+  activateSection('evaluation-section');
+  renderHistory(id);
+}
+
+function playerAverage(id) {
+  const evals = evaluations.filter(e => e.playerId === id);
+  if (evals.length === 0) return null;
+  const avg = {};
+  evalKeys.forEach(k => {
+    avg[k] = evals.reduce((sum, e) => sum + Number(e[k] || 0), 0) / evals.length;
+  });
+  return avg;
+}
+
+function teamAverage() {
+  if (evaluations.length === 0) return null;
+  const avg = {};
+  evalKeys.forEach(k => {
+    avg[k] = evaluations.reduce((sum, e) => sum + Number(e[k] || 0), 0) / evaluations.length;
+  });
+  return avg;
+}
+
+function renderHistory(playerId) {
+  const container = document.getElementById('history-table');
+  container.innerHTML = '';
+  const evals = evaluations.filter(e => e.playerId === playerId);
+  if (evals.length === 0) {
+    container.textContent = 'Sin evaluaciones';
+    return;
+  }
+  const table = document.createElement('table');
+  const header = document.createElement('tr');
+  ['Fecha', ...evalKeys.map(k => k.charAt(0).toUpperCase()) , ''].forEach(t => {
+    const th = document.createElement('th');
+    th.textContent = t;
+    header.appendChild(th);
+  });
+  table.appendChild(header);
+  evals.forEach(ev => {
+    const tr = document.createElement('tr');
+    const tdDate = document.createElement('td');
+    tdDate.textContent = ev.date;
+    tr.appendChild(tdDate);
+    evalKeys.forEach(k => {
+      const td = document.createElement('td');
+      td.textContent = ev[k];
+      tr.appendChild(td);
+    });
+    const btnTd = document.createElement('td');
+    const btn = document.createElement('button');
+    btn.textContent = 'Comparar';
+    btn.onclick = () => renderComparison(ev);
+    btnTd.appendChild(btn);
+    tr.appendChild(btnTd);
+    table.appendChild(tr);
+  });
+  container.appendChild(table);
+}
+
+function renderComparison(entry) {
+  const teamAvg = teamAverage();
+  const container = document.getElementById('compare-results');
+  container.innerHTML = '';
+  if (!entry || !teamAvg) {
+    container.textContent = 'Sin datos para comparar.';
+    return;
+  }
+  const table = document.createElement('table');
+  const header = document.createElement('tr');
+  ['Característica','Jugador','Equipo'].forEach(t => {
+    const th = document.createElement('th');
+    th.textContent = t;
+    header.appendChild(th);
+  });
+  table.appendChild(header);
+
+  evalKeys.forEach(k => {
+    const tr = document.createElement('tr');
+    const tdK = document.createElement('td');
+    tdK.textContent = k;
+    const tdP = document.createElement('td');
+    tdP.textContent = Number(entry[k] || 0).toFixed(2);
+    const tdT = document.createElement('td');
+    tdT.textContent = teamAvg[k].toFixed(2);
+    tr.appendChild(tdK);
+    tr.appendChild(tdP);
+    tr.appendChild(tdT);
+    table.appendChild(tr);
+  });
+  container.appendChild(table);
+
+  // render chart
+  const ctx = document.getElementById('compare-chart').getContext('2d');
+  if (compareChart) compareChart.destroy();
+  compareChart = new Chart(ctx, {
+    type: 'radar',
+    data: {
+      labels: evalKeys,
+      datasets: [
+        {
+          label: 'Jugador',
+          data: evalKeys.map(k => Number(entry[k] || 0)),
+          backgroundColor: 'rgba(54, 162, 235, 0.2)',
+          borderColor: 'rgba(54, 162, 235, 1)'
+        },
+        {
+          label: 'Equipo',
+          data: evalKeys.map(k => teamAvg[k]),
+          backgroundColor: 'rgba(255, 99, 132, 0.2)',
+          borderColor: 'rgba(255, 99, 132, 1)'
+        }
+      ]
+    },
+    options: {
+      scales: {
+        r: {
+          beginAtZero: true,
+          max: 10
+        }
+      }
+    }
+  });
+}
+
+// export/import helpers
+function exportData() {
+  const data = { players, evaluations };
+  const blob = new Blob([JSON.stringify(data, null, 2)], {
+    type: 'application/json'
+  });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'entreno.json';
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+  alert('Datos exportados correctamente');
+}
+
+function importData(file) {
+  const reader = new FileReader();
+  reader.onload = e => {
+    try {
+      const data = JSON.parse(e.target.result);
+      if (Array.isArray(data.players) && Array.isArray(data.evaluations)) {
+        players = data.players;
+        evaluations = data.evaluations;
+        savePlayers();
+        saveEvaluations();
+        renderPlayers();
+        renderPlayerCards();
+        const current = document.getElementById('player-id').value;
+        if (current) {
+          renderHistory(current);
+        }
+      } else {
+        alert('Archivo no válido');
+      }
+    } catch (err) {
+      alert('Archivo no válido');
+    }
+  };
+  reader.readAsText(file);
+}
+
+// form handlers
+
+document.getElementById('player-form').addEventListener('submit', e => {
+  e.preventDefault();
+  const id = document.getElementById('player-id').value;
+  const name = document.getElementById('player-name').value;
+  const pos1 = document.getElementById('player-pos1').value;
+  const pos2 = document.getElementById('player-pos2').value;
+  if (id) {
+    const p = players.find(pl => pl.id === id);
+    if (p) {
+      p.name = name;
+      p.pos1 = pos1;
+      p.pos2 = pos2;
+    }
+  } else {
+    players.push({ id: Date.now().toString(), name, pos1, pos2 });
+  }
+  savePlayers();
+  renderPlayers();
+  renderPlayerCards();
+  e.target.reset();
+});
+
+document.getElementById('evaluation-form').addEventListener('submit', e => {
+  e.preventDefault();
+  const playerId = document.getElementById('player-id').value;
+  const entry = {
+    playerId,
+    date: document.getElementById('eval-date').value,
+    energia: document.getElementById('eval-energia').value,
+    concentracion: document.getElementById('eval-concentracion').value,
+    control: document.getElementById('eval-control').value,
+    pase: document.getElementById('eval-pase').value,
+    regate: document.getElementById('eval-regate').value,
+    disparo: document.getElementById('eval-disparo').value,
+    vision: document.getElementById('eval-vision').value,
+    velocidad: document.getElementById('eval-velocidad').value
+  };
+  evaluations.push(entry);
+  saveEvaluations();
+  renderHistory(playerId);
+  renderComparison(entry);
+  renderPlayerCards();
+  e.target.reset();
+});
+
+document.getElementById('export-btn').addEventListener('click', exportData);
+document.getElementById('import-file').addEventListener('change', e => {
+  const file = e.target.files[0];
+  if (file) importData(file);
+  e.target.value = '';
+});
+
+// navigation helpers
+function activateSection(sectionId) {
+  document.querySelectorAll('section').forEach(sec => {
+    const keep =
+      sec.id === sectionId ||
+      (sectionId === 'evaluation-section' &&
+        ['evaluation-section', 'history-section', 'compare-section'].includes(sec.id)) ||
+      (sectionId === 'players-list-section' && sec.id === 'player-form-section');
+
+    if (keep) {
+      sec.classList.remove('hidden');
+    } else {
+      sec.classList.add('hidden');
+    }
+  });
+  document.querySelectorAll('#bottom-nav button').forEach(btn => {
+    if (btn.dataset.target === sectionId) {
+      btn.classList.add('active');
+    } else {
+      btn.classList.remove('active');
+    }
+  });
+  if (sectionId === 'players-cards') renderPlayerCards();
+  window.scrollTo({ top: 0, behavior: 'smooth' });
+}
+
+document.querySelectorAll('#bottom-nav button').forEach(btn => {
+  btn.addEventListener('click', () => {
+    activateSection(btn.dataset.target);
+  });
+});
+
+// initial render
+renderPlayers();
+renderPlayerCards();
+activateSection('players-list-section');

--- a/index.html
+++ b/index.html
@@ -1,0 +1,199 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Control de Entreno - Ciutat de Palma</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      background: #f5f5f5;
+      margin: 20px auto;
+      max-width: 800px;
+    }
+
+    h1 {
+      text-align: center;
+      color: #0b5394;
+    }
+
+    label {
+      display: block;
+      margin-top: 10px;
+    }
+
+    input, button {
+      padding: 5px;
+      margin-top: 5px;
+    }
+
+    button {
+      background: #0b5394;
+      color: #fff;
+      border: none;
+      padding: 8px 12px;
+      cursor: pointer;
+    }
+
+    button:hover {
+      background: #073763;
+    }
+
+    section {
+      margin-bottom: 30px;
+    }
+
+    ul#players-list {
+      list-style: none;
+      padding: 0;
+    }
+
+    ul#players-list li {
+      margin-bottom: 5px;
+    }
+
+    #players-cards {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+    }
+
+    .player-card {
+      background: #fff;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+      padding: 10px;
+      width: 180px;
+    }
+
+    .player-card h3 {
+      margin-top: 0;
+      margin-bottom: 5px;
+    }
+
+    #bottom-nav {
+      position: fixed;
+      bottom: 0;
+      left: 0;
+      width: 100%;
+      background: #0b5394;
+      display: flex;
+      justify-content: space-around;
+    }
+
+    #bottom-nav button {
+      flex: 1;
+      background: none;
+      color: #fff;
+      border: none;
+      padding: 10px 0;
+      cursor: pointer;
+    }
+
+    #bottom-nav button.active {
+      background: #073763;
+    }
+
+    table {
+      border-collapse: collapse;
+      width: 100%;
+    }
+
+    th, td {
+      border: 1px solid #ccc;
+      padding: 5px;
+      text-align: center;
+    }
+
+    tr:nth-child(even) {
+      background: #eee;
+    }
+
+    .hidden {
+      display: none;
+    }
+
+    .import-label {
+      border: 1px solid #0b5394;
+      padding: 6px 12px;
+      color: #0b5394;
+      cursor: pointer;
+    }
+
+    .import-label input {
+      display: none;
+    }
+
+    #export-btn {
+      margin-right: 10px;
+    }
+  </style>
+</head>
+<body>
+  <h1>Evaluación de Jugadores - Prebenjamín 1º Año</h1>
+
+  <section id="player-form-section">
+    <h2>Registrar/Editar Jugador</h2>
+    <form id="player-form">
+      <input type="hidden" id="player-id">
+      <label>Nombre <input type="text" id="player-name" required></label>
+      <label>Posición Principal <input type="text" id="player-pos1" required></label>
+      <label>Posición Secundaria <input type="text" id="player-pos2"></label>
+      <button type="submit">Guardar Jugador</button>
+    </form>
+  </section>
+
+  <section id="players-list-section">
+    <h2>Jugadores</h2>
+    <ul id="players-list"></ul>
+  </section>
+
+  <section id="players-cards" class="hidden">
+    <h2>Fichas de Jugadores</h2>
+  </section>
+
+  <section id="evaluation-section" class="hidden">
+    <h2>Evaluar Jugador</h2>
+    <h3 id="evaluation-player-name"></h3>
+    <form id="evaluation-form">
+      <label>Fecha <input type="date" id="eval-date" required></label>
+      <label>Energía <input type="number" id="eval-energia" min="0" max="10" required></label>
+      <label>Concentración <input type="number" id="eval-concentracion" min="0" max="10" required></label>
+      <label>Control <input type="number" id="eval-control" min="0" max="10" required></label>
+      <label>Pase <input type="number" id="eval-pase" min="0" max="10" required></label>
+      <label>Regate <input type="number" id="eval-regate" min="0" max="10" required></label>
+      <label>Disparo <input type="number" id="eval-disparo" min="0" max="10" required></label>
+      <label>Visión <input type="number" id="eval-vision" min="0" max="10" required></label>
+      <label>Velocidad <input type="number" id="eval-velocidad" min="0" max="10" required></label>
+      <button type="submit">Guardar Evaluación</button>
+    </form>
+  </section>
+
+  <section id="history-section" class="hidden">
+    <h2>Historial de Evaluaciones</h2>
+    <div id="history-table"></div>
+  </section>
+
+  <section id="compare-section" class="hidden">
+    <h2>Comparar con Media del Equipo</h2>
+    <div id="compare-results"></div>
+    <canvas id="compare-chart" width="400" height="300"></canvas>
+  </section>
+
+  <section id="data-section">
+    <h2>Datos</h2>
+    <button id="export-btn">Exportar Datos</button>
+    <label for="import-file" class="import-label">Importar Datos</label>
+    <input type="file" id="import-file" accept="application/json" class="hidden">
+  </section>
+
+  <nav id="bottom-nav">
+    <button type="button" data-target="players-list-section" class="active">🏠<br>Inicio</button>
+    <button type="button" data-target="players-cards">👥<br>Jugadores</button>
+    <button type="button" data-target="evaluation-section">📝<br>Evaluar</button>
+    <button type="button" data-target="data-section">💾<br>Datos</button>
+  </nav>
+
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script type="module" src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add bottom navigation and player cards
- render player averages on cards
- update README with new navigation info
- fix bottom navigation switching

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841a3bd3e50832981951a873be77d83